### PR TITLE
add `profiler:data` primitive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /project/project
 target/
 .bundledFiles
+.idea

--- a/README.md
+++ b/README.md
@@ -48,6 +48,38 @@ print profiler:report  ;; view the results
 profiler:reset         ;; clear the data
 ```
 
+Another way to use the profiler is to export its raw data using
+the [`csv` extension](https://ccl.northwestern.edu/netlogo/docs/csv.html)
+and the `profiler:data` primitive:
+
+```NetLogo
+extensions [ csv profiler ]
+
+to profile
+  setup                                          ;; set up the model
+  profiler:start                                 ;; start profiling
+  repeat 20 [ go ]                               ;; run something you want to measure
+  profiler:stop                                  ;; stop profiling
+  csv:to-file "profiler_data.csv" profiler:data  ;; save the results
+  profiler:reset                                 ;; clear the data  
+end
+```
+
+Running the above procedure will write a `profiler_data.csv` file that you can then load into your
+favorite data analysis program. Here is an example data file produced using
+the [Wolf Sheep Predation](https://ccl.northwestern.edu/netlogo/models/WolfSheepPredation) model:
+
+```CSV
+procedure,calls,inclusive_time,exclusive_time
+EAT-SHEEP,1066,330097,1576317
+DISPLAY-LABELS,20,528997,528997
+MOVE,3467,2223759,2223759
+GO,20,12153531,4767136
+DEATH,1066,625185,625185
+REPRODUCE-SHEEP,2401,1459481,1459481
+REPRODUCE-WOLVES,1027,972656,972656
+```
+
 Thanks to Roger Peppe for his contributions to the code.
 
 
@@ -60,6 +92,7 @@ Thanks to Roger Peppe for his contributions to the code.
 [`profiler:stop`](#profilerstop)
 [`profiler:reset`](#profilerreset)
 [`profiler:report`](#profilerreport)
+[`profiler:data`](#profilerdata)
 
 
 ### `profiler:calls`
@@ -170,6 +203,22 @@ Sorted by Number of Calls
 Name                               Calls Incl T(ms) Excl T(ms) Excl/calls
 CALLTHEM                              13     26.066     19.476      1.498
 ```
+
+
+
+### `profiler:data`
+
+```NetLogo
+profiler:data
+```
+
+
+Reports a list of lists containing the results of the profiler in a format that is suitable
+for exporting with the [`csv` extension](https://ccl.northwestern.edu/netlogo/docs/csv.html).
+
+The first sublist contains the name of the data columns: `procedure`, `calls`, `inclusive_time` and
+`exclusive_time`. This is followed by one sublist containing the profiler data for each user-defined
+procedure. The reported times are in milliseconds.
 
 
 

--- a/USING.md
+++ b/USING.md
@@ -37,5 +37,37 @@ print profiler:report  ;; view the results
 profiler:reset         ;; clear the data
 ```
 
+Another way to use the profiler is to export its raw data using
+the [`csv` extension](https://ccl.northwestern.edu/netlogo/docs/csv.html)
+and the `profiler:data` primitive:
+
+```NetLogo
+extensions [ csv profiler ]
+
+to profile
+  setup                                          ;; set up the model
+  profiler:start                                 ;; start profiling
+  repeat 20 [ go ]                               ;; run something you want to measure
+  profiler:stop                                  ;; stop profiling
+  csv:to-file "profiler_data.csv" profiler:data  ;; save the results
+  profiler:reset                                 ;; clear the data  
+end
+```
+
+Running the above procedure will write a `profiler_data.csv` file that you can then load into your
+favorite data analysis program. Here is an example data file produced using
+the [Wolf Sheep Predation](https://ccl.northwestern.edu/netlogo/models/WolfSheepPredation) model:
+
+```CSV
+procedure,calls,inclusive_time,exclusive_time
+EAT-SHEEP,1066,330097,1576317
+DISPLAY-LABELS,20,528997,528997
+MOVE,3467,2223759,2223759
+GO,20,12153531,4767136
+DEATH,1066,625185,625185
+REPRODUCE-SHEEP,2401,1459481,1459481
+REPRODUCE-WOLVES,1027,972656,972656
+```
+
 Thanks to Roger Peppe for his contributions to the code.
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ netLogoZipSources   := false
 javaSource in Compile := baseDirectory.value / "src"
 
 javacOptions ++= Seq("-g", "-Xlint:deprecation", "-Xlint:all", "-Xlint:-serial", "-Xlint:-path",
-  "-encoding", "us-ascii")
+  "-encoding", "us-ascii", "-source", "1.8", "-target", "1.8")
 
 resolvers      += "netlogo" at "https://dl.cloudsmith.io/public/netlogo/netlogo/maven/"
 netLogoVersion := "6.2.0-d27b502"

--- a/documentation.conf
+++ b/documentation.conf
@@ -121,5 +121,18 @@ Name                               Calls Incl T(ms) Excl T(ms) Excl/calls
 CALLTHEM                              13     26.066     19.476      1.498
 ```
 """
+  },
+  {
+    name: data,
+    type: reporter,
+    returns: list,
+    description: """
+Reports a list of lists containing the results of the profiler in a format that is suitable
+for exporting with the [`csv` extension](https://ccl.northwestern.edu/netlogo/docs/csv.html).
+
+The first sublist contains the name of the data columns: `procedure`, `calls`, `inclusive_time` and
+`exclusive_time`. This is followed by one sublist containing the profiler data for each user-defined
+procedure. The reported times are in milliseconds.
+"""
   }
 ]

--- a/src/ProfilerExtension.java
+++ b/src/ProfilerExtension.java
@@ -86,7 +86,7 @@ public class ProfilerExtension extends org.nlogo.api.DefaultClassManager {
 
   public static class ProfilerReport implements Reporter {
     public Syntax getSyntax() {
-      return SyntaxJ.reporterSyntax(Syntax.ListType());
+      return SyntaxJ.reporterSyntax(Syntax.StringType());
     }
 
     public Object report(Argument args[], Context context) throws ExtensionException {

--- a/src/QuickTracer.java
+++ b/src/QuickTracer.java
@@ -1,10 +1,12 @@
 package org.nlogo.extensions.profiler;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Comparator;
 import java.util.Arrays;
 
+import java.util.Set;
 import org.nlogo.nvm.Activation;
 import org.nlogo.nvm.Context;
 import org.nlogo.nvm.Procedure;
@@ -211,5 +213,9 @@ public class QuickTracer extends org.nlogo.nvm.Tracer {
       return records.get(proc);
     }
     return new Record();
+  }
+
+  public Set<String> procedureNames() {
+    return Collections.unmodifiableSet(procedureNames.keySet());
   }
 }


### PR DESCRIPTION
I have long wanted something like that for myself, but I'm hoping it might be useful to others.

This just adds a `profiler:data` primitive that reports the profiler data in a format suitable for exporting with the `csv` extension (i.e., a list of lists).

A few notes:

- I added a `procedureNames()` method the the `QuickTracer` class. I *think* it would make sense to add this method to the [`Tracer`](https://github.com/NetLogo/NetLogo/blob/hexy/netlogo-core/src/main/nvm/Tracer.scala) in the main code base, but that's a call I'd rather leave to the dev team.
- As far as I can tell, the `ProfilingTracer` is just a leftover old version and not used anywhere. I didn't scrap it, but it's something that might be considered.
- The return type of the old `profiler:report` primitive was wrong (`Syntax.ListType()` instead of `Syntax.StringType()`). It doesn't seem to have hurt anything all these years, but I still updated it.
- The extension has no tests, so I didn't add any.

It's been a while since I've done anything like that so please don't hesitate if there is anything I've overlooked. Happy to make fixes and polish the whole thing as needed.
